### PR TITLE
Install: add `-DLIBVERSION_STATIC_DEFINE` to `Cflags` in the pkg-config file on Windows.

### DIFF
--- a/libversion/CMakeLists.txt
+++ b/libversion/CMakeLists.txt
@@ -68,6 +68,9 @@ target_compile_definitions(libversion_object PUBLIC
 )
 
 # pkgconfig file
+if(WIN32)
+	set(EXTRA_CFLAGS "-DLIBVERSION_STATIC_DEFINE")
+endif()
 configure_file(libversion.pc.in libversion.pc @ONLY)
 
 # installation

--- a/libversion/libversion.pc.in
+++ b/libversion/libversion.pc.in
@@ -7,5 +7,5 @@ Name: libversion
 Description: Version comparison library
 Version: @libversion_VERSION@
 Libs: -L${libdir} -lversion
-Cflags: -I${includedir}
+Cflags: -I${includedir} @EXTRA_CFLAGS@
 Cflags.private: -DLIBVERSION_STATIC_DEFINE


### PR DESCRIPTION
Fixes https://github.com/repology/libversion/issues/26.

I have chosen the solution 1, because I don't know how to properly install the DLL, especially using `cmake`.