### PR TITLE
fix library installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 # meta
 project(libversion VERSION 3.0.1)
 
-set(PKGCONFIGDIR lib/pkgconfig CACHE STRING "directory where to install pkg-config files")
+set(PKGCONFIGDIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE STRING "directory where to install pkg-config files")
 if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "DragonFly")
 	SET(PKGCONFIGDIR libdata/pkgconfig)
 endif()

--- a/libversion/CMakeLists.txt
+++ b/libversion/CMakeLists.txt
@@ -77,8 +77,8 @@ install(FILES
 	${CMAKE_CURRENT_BINARY_DIR}/export.h
 	DESTINATION include/libversion
 )
-install(TARGETS libversion libversion_static EXPORT libversion LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+install(TARGETS libversion libversion_static EXPORT libversion LIBRARY ARCHIVE)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libversion.pc DESTINATION ${PKGCONFIGDIR})
 
-install(EXPORT libversion NAMESPACE libversion:: DESTINATION lib/cmake/libversion FILE libversionConfig.cmake)
+install(EXPORT libversion NAMESPACE libversion:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libversion FILE libversionConfig.cmake)

--- a/libversion/libversion.pc.in
+++ b/libversion/libversion.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: libversion


### PR DESCRIPTION
Replace hardcoded library files installation paths using CMAKE_INSTALL_LIBDIR flag with default value 'lib' to ease handling actual installation location depending on target platform architecture.